### PR TITLE
Fix tree farm

### DIFF
--- a/cheat-library/src/user/cheat/world/AutoTreeFarm.cpp
+++ b/cheat-library/src/user/cheat/world/AutoTreeFarm.cpp
@@ -158,7 +158,6 @@ namespace cheat::feature
 	void AutoTreeFarm::OnGameUpdate()
 	{
 		static lra_map<Vector3d, uint32_t, 10, hash_fn> s_AttackCountMap;
-
 		static std::queue<app::SceneTreeObject*> s_AttackQueue;
 		static std::unordered_set<app::SceneTreeObject*> s_AttackQueueSet;
 		static uint64_t s_LastAttackTimestamp = 0;
@@ -179,7 +178,7 @@ namespace cheat::feature
 			if (s_AttackQueueSet.count(tree) > 0)
 				continue;
 
-			if (tree->fields._lastTreeDropTimeStamp + m_RepeatDelay > timestamp)
+			if (s_LastAttackTimestamp + m_RepeatDelay > timestamp)
 				continue;
 
 			auto position = tree->fields._.realBounds.m_Center;
@@ -220,7 +219,7 @@ namespace cheat::feature
 					continue;
 			}
 
-			tree->fields._lastTreeDropTimeStamp = timestamp;
+			s_LastAttackTimestamp = timestamp;
 			app::MoleMole_NetworkManager_RequestHitTreeDropNotify(networkManager, position, position, treeType, nullptr);
 			break;
 		}


### PR DESCRIPTION
Hi!
I've noticed the tree farm cheat has a little problem: it only resets the trees that have been farmed after 1000 trees have been added to the hash map that keeps track of them.

Maybe little known fact, there's a mechanic in Genshin specifically about this: if you hit 11 trees in a row, the 1st one resets.
You can try this out without any cheats and you'll see that the game only keeps track of 10 trees at a time. In fact, you don't even have to exhaust a tree (i.e. hit it for 3 wood pieces); it is sufficient to hit a tree only once to count towards this list that's being tracked.
(Note: there's actually a bug/feature in the Genshin codebase where if you hit 9 trees in a row, go back to the first tree and hit it, then hit a 10th tree (which should reset the first tree), you'll find that the first tree was not actually reset (maybe it puts it back on top of the stack?)).

In any case, I have a fix for this: use a LRA (last recently added) map.
This map keeps track of N elements at a time. When the N+1 element is added, it pops the first element (keeping track of the order they were added).

This should work similar to the code Genshin is using (sans the aforementioned bug/feature) which should allow players to farm wood in a relatively small area.
For example, Amakane Island (west of Narukami Islands) has enough Yumemiru wood to easily go in a circle and quickly build up inventory
![Untitled-1](https://user-images.githubusercontent.com/30932040/174185613-5ceda242-1cec-4dd3-a9f4-be7d0638a5c3.png)


Feel free to add/modify/remove any code that you feel is out of place