### PR TITLE
Fixed AutoFish delays ImGui labels having same id

### DIFF
--- a/cheat-library/src/user/cheat/world/AutoFish.cpp
+++ b/cheat-library/src/user/cheat/world/AutoFish.cpp
@@ -34,12 +34,12 @@ namespace cheat::feature
     void AutoFish::DrawMain()
     {
         ConfigWidget("Enabled", f_Enabled, "Automatically catch fish.");
-        ConfigWidget("Delay (ms)", f_DelayBeforeCatch, 100, 500, 4000, "Fish will be caught after this delay (in ms).");
+        ConfigWidget("Catch Delay (ms)", f_DelayBeforeCatch, 100, 500, 4000, "Fish will be caught after this delay (in ms).");
 
         ImGui::Spacing();
 
         ConfigWidget(f_AutoRecastRod, "If enabled, rod will recasted. Without visualization.");
-        ConfigWidget("Delay (ms)", f_DelayBeforeRecast, 10, 100, 4000, "Rod will be recast after this delay (in ms).");
+        ConfigWidget("Recast Delay (ms)", f_DelayBeforeRecast, 10, 100, 4000, "Rod will be recast after this delay (in ms).");
     }
 
     bool AutoFish::NeedStatusDraw() const


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4395401/177189321-ae4a9530-0ac3-4187-a52a-ff749982dc70.png)

Labels had the same text, so they were bugging while editing one, it would change the other.

Now they have different labels, so it works correctly.