### PR TITLE
added Mob Drop Radius to vacuum and added RadishDrop and CarrotDrop to filter

### DIFF
--- a/cheat-library/src/user/cheat/game/filters.cpp
+++ b/cheat-library/src/user/cheat/game/filters.cpp
@@ -47,7 +47,7 @@ namespace cheat::game::filters
 		SimpleFilter Electrogranum = { app::EntityType__Enum_1::Gadget, "ThunderSeedCreate" };
 		SimpleFilter FishingPoint = { app::EntityType__Enum_1::FishPool, "_FishingShoal" };
 		SimpleFilter Geoculus = { app::EntityType__Enum_1::GatherObject, "RockCrystalShell" };
-		WhitelistFilter ItemDrops = { std::vector<app::EntityType__Enum_1> {app::EntityType__Enum_1::GatherObject, app::EntityType__Enum_1::DropItem }, std::vector<std::string> {"_Food_BirdMeat", "_Food_Meat", "_DropItem" } };
+		WhitelistFilter ItemDrops = { std::vector<app::EntityType__Enum_1> {app::EntityType__Enum_1::GatherObject, app::EntityType__Enum_1::DropItem }, std::vector<std::string> {"_Food_BirdMeat", "_Food_Meat", "_DropItem","_Fishmeat" } };
 		SimpleFilter Lumenspar = { app::EntityType__Enum_1::GatherObject, "CelestiaSplinter" };
 		SimpleFilter KeySigil = { app::EntityType__Enum_1::GatherObject, "RuneContent" };
 		SimpleFilter ShrineOfDepth = { app::EntityType__Enum_1::Gadget, "Temple" };
@@ -103,7 +103,7 @@ namespace cheat::game::filters
 		SimpleFilter WeaselThief = { app::EntityType__Enum_1::Monster, "Thoarder_Weasel" };
 		SimpleFilter Kitsune = { app::EntityType__Enum_1::EnvAnimal, "Vulpes" };
 		SimpleFilter BakeDanuki = { app::EntityType__Enum_1::Monster, "Inu_Tanuki" };
-		SimpleFilter Meat = { app::EntityType__Enum_1::GatherObject , std::vector<std::string> { "_Food_BirdMeat", "_Food_Meat", "_Fishmeat" }};
+		SimpleFilter Meat = { app::EntityType__Enum_1::GatherObject , std::vector<std::string> { "_Food_BirdMeat", "_Food_Meat", "_Fishmeat" } };
 	}
 
 	namespace mineral
@@ -125,7 +125,7 @@ namespace cheat::game::filters
 		SimpleFilter DunlinsTooth = { app::EntityType__Enum_1::GatherObject, "_DunlinsTooth" };
 
 		SimpleFilter AmethystLumpDrop = { app::EntityType__Enum_1::GatherObject, "_Thundercrystaldrop" };
-		SimpleFilter CrystalChunkDrop = { app::EntityType__Enum_1::GatherObject,"_Drop_Crystal"};
+		SimpleFilter CrystalChunkDrop = { app::EntityType__Enum_1::GatherObject,"_Drop_Crystal" };
 		SimpleFilter ElectroCrystalDrop = { app::EntityType__Enum_1::GatherObject, "_Drop_Ore_ElectricRock" };
 		SimpleFilter IronChunkDrop = { app::EntityType__Enum_1::GatherObject, "_Drop_Stone" };
 		SimpleFilter NoctilucousJadeDrop = { app::EntityType__Enum_1::GatherObject,"_NightBerth" };
@@ -153,7 +153,7 @@ namespace cheat::game::filters
 		SimpleFilter RuinGrader = { app::EntityType__Enum_1::Monster, "_Konungmathr" };
 		SimpleFilter RuinSentinel = { app::EntityType__Enum_1::Monster, "_Apparatus_Enigma" };
 		SimpleFilter Samachurl = { app::EntityType__Enum_1::Monster, "_Shaman" };
-	    SimpleFilter ShadowyHusk = { app::EntityType__Enum_1::Monster, "ForlornVessel_Strong" };
+		SimpleFilter ShadowyHusk = { app::EntityType__Enum_1::Monster, "ForlornVessel_Strong" };
 		SimpleFilter Slime = { app::EntityType__Enum_1::Monster, "_Slime" };
 		SimpleFilter FloatingFungus = { app::EntityType__Enum_1::Monster, "_Fungus" };
 		SimpleFilter Specter = { app::EntityType__Enum_1::Monster, "_Sylph" };
@@ -250,6 +250,8 @@ namespace cheat::game::filters
 		SimpleFilter Wheat = { app::EntityType__Enum_1::GatherObject, "_Plant_Wheat" };
 		SimpleFilter WindwheelAster = { app::EntityType__Enum_1::GatherObject, "_WindmilDaisy" };
 		SimpleFilter Wolfhook = { app::EntityType__Enum_1::GatherObject, "_GogoFruit" };
+		SimpleFilter RadishDrop = { app::EntityType__Enum_1::GatherObject, "_Plant_Carrot02_Clear" };
+		SimpleFilter CarrotDrop = { app::EntityType__Enum_1::GatherObject, "_Plant_Radish02_Clear" };
 	}
 
 	namespace puzzle
@@ -257,7 +259,7 @@ namespace cheat::game::filters
 		SimpleFilter AncientRime = { app::EntityType__Enum_1::Gadget, "_IceSolidBulk" };
 		SimpleFilter BakeDanuki = { app::EntityType__Enum_1::Monster, "Animal_Inu_Tanuki_" };
 		SimpleFilter BloattyFloatty = { app::EntityType__Enum_1::Field, "_Flower_PongPongTree_" };
-		WhitelistFilter CubeDevices = { std::vector<app::EntityType__Enum_1> {app::EntityType__Enum_1::Gadget, app::EntityType__Enum_1::Platform }, std::vector<std::string> {"_ElecStone", "_ElecSwitch" }};
+		WhitelistFilter CubeDevices = { std::vector<app::EntityType__Enum_1> {app::EntityType__Enum_1::Gadget, app::EntityType__Enum_1::Platform }, std::vector<std::string> {"_ElecStone", "_ElecSwitch" } };
 		SimpleFilter EightStoneTablets = { app::EntityType__Enum_1::Gadget, "_HistoryBoard" };
 		SimpleFilter ElectricConduction = { app::EntityType__Enum_1::Gear, "_ElectricPowerSource" };
 		SimpleFilter RelayStone = { app::EntityType__Enum_1::Worktop, "_ElectricTransfer_" };
@@ -475,11 +477,11 @@ namespace cheat::game::filters
 				app::EntityType__Enum_1::Monster
 			},
 			std::vector<std::string> {
-				// Environmental mobs
-				"Cat", "DogPrick", "Vulpues", "Inu_Tanuki",
-				// Overworld bosses
-				"Ningyo", "Regisvine", "Hypostasis", "Planelurker", "Nithhoggr"
-			}
+					// Environmental mobs
+					"Cat", "DogPrick", "Vulpues", "Inu_Tanuki",
+						// Overworld bosses
+						"Ningyo", "Regisvine", "Hypostasis", "Planelurker", "Nithhoggr"
+					}
 		};
 		SimpleFilter OrganicTargets = Monsters + Animals; // Solael: Please don't mess around with this filter.
 		//m0nkrel: We can choose the entities we need ourselves so as not to magnetize cats, dogs, etc.

--- a/cheat-library/src/user/cheat/game/filters.h
+++ b/cheat-library/src/user/cheat/game/filters.h
@@ -247,6 +247,8 @@ namespace cheat::game::filters
 		extern SimpleFilter Wheat;
 		extern SimpleFilter WindwheelAster;
 		extern SimpleFilter Wolfhook;
+		extern SimpleFilter RadishDrop;
+		extern SimpleFilter CarrotDrop;
 	}
 
 	namespace puzzle
@@ -255,7 +257,7 @@ namespace cheat::game::filters
 		extern SimpleFilter BakeDanuki;
 		extern SimpleFilter BloattyFloatty;
 		extern WhitelistFilter CubeDevices;
-		
+
 		extern SimpleFilter EightStoneTablets;
 		extern SimpleFilter ElectricConduction;
 		extern SimpleFilter RelayStone;
@@ -302,7 +304,7 @@ namespace cheat::game::filters
 		extern SimpleFilter MonsterBosses;
 		extern SimpleFilter MonsterShielded;
 		extern SimpleFilter MonsterEquips;
-        extern BlacklistFilter Living;
+		extern BlacklistFilter Living;
 		extern SimpleFilter OrganicTargets;
 	}
 }

--- a/cheat-library/src/user/cheat/world/VacuumLoot.h
+++ b/cheat-library/src/user/cheat/world/VacuumLoot.h
@@ -15,6 +15,7 @@ namespace cheat::feature
 		config::Field<config::Toggle<Hotkey>> f_Enabled;
 		config::Field<float> f_Distance;
 		config::Field<float> f_Radius;
+		config::Field<float> f_MobDropRadius;
 		config::Field<int> f_DelayTime;
 
 		static VacuumLoot& GetInstance();
@@ -31,14 +32,22 @@ namespace cheat::feature
 		using FilterInfo = std::pair<config::Field<bool>, game::IEntityFilter*>;
 		using Filters = std::vector<FilterInfo>;
 		using Sections = std::map<std::string, Filters>;
+		using FilterInfoMobDrop = std::pair<config::Field<bool>, game::IEntityFilter*>;
+		using filtersMobDrop = std::vector<FilterInfoMobDrop>;
+		using SectionsMobDrop = std::map<std::string, filtersMobDrop>;
 
 		Sections m_Sections;
+		SectionsMobDrop m_SectionsMobDrop;
 		SafeValue<int64_t> nextTime;
 
 		VacuumLoot();
 		void DrawSection(const std::string& section, const Filters& filters);
+		void DrawSectionMobDrop(const std::string& sectionMobDrop, const filtersMobDrop& filtersMobDrop);
 		void InstallFilters();
+		void InstallFiltersMobDrop();
 		void AddFilter(const std::string& section, const std::string& name, game::IEntityFilter* filter);
+		void AddFilterMobDrop(const std::string& sectionMobDrop, const std::string& nameMobDrop, game::IEntityFilter* filterMobDrop);
 		bool IsEntityForVac(cheat::game::Entity* entity);
+		bool IsEntityForMobDropVac(cheat::game::Entity* entity);
 	};
 }


### PR DESCRIPTION
 so mob drops can work better with large kill aura's and added RadishDrop and CarrotDrop so the vacuum don't pick up the ones in the ground and added Fishmeat to ItemDrops so if you use instant kill aura it grabs the fish that drops.

there is probably a better way of doing this I just couldn't figure it out