### PR TITLE
(Reopen) Added ElectroSeelie support

### DIFF
--- a/cheat-library/src/user/cheat/world/AutoSeelie.cpp
+++ b/cheat-library/src/user/cheat/world/AutoSeelie.cpp
@@ -9,22 +9,33 @@
 namespace cheat::feature
 {
 	AutoSeelie::AutoSeelie() : Feature(),
-		NF(f_Enabled, "Auto follow seelie", "AutoSeelie", false)
-    {
-        events::GameUpdateEvent += MY_METHOD_HANDLER(AutoSeelie::OnGameUpdate);
-    }
+		NF(f_Enabled, "Auto seelie", "Auto Seelie", false),
+		NF(f_ElectroSeelie, "Auto Electro seelie", "Auto Seelie", false),
+		nextTime(0)
+	{
+		events::GameUpdateEvent += MY_METHOD_HANDLER(AutoSeelie::OnGameUpdate);
+	}
 	const FeatureGUIInfo& AutoSeelie::GetGUIInfo() const
 	{
 		static const FeatureGUIInfo info{ "", "World", true };
 		return info;
 	}
 
-    void AutoSeelie::DrawMain()
-    {
-        ConfigWidget("Auto seelie", f_Enabled, "Auto follow seelie to its home");
-		ImGui::SameLine();
-		ImGui::TextColored(ImColor(255, 165, 0, 255), "Don't work with Electro Seelies");
-    }
+	void AutoSeelie::DrawMain()
+	{
+		ConfigWidget("Auto seelie", f_Enabled, "Auto follow seelie to its home");
+
+		if (f_Enabled)
+		{
+			ImGui::Indent();
+			ConfigWidget("Auto Electro seelie", f_ElectroSeelie, "Since you don't need to manually start electroseelie, \n"
+				"they start moving automatically with this option within 100m radius.");
+			ImGui::SameLine();
+			ImGui::TextColored(ImColor(255, 165, 0, 255), "Read the note!");
+			ImGui::Unindent();
+		}
+
+	}
 
 	bool AutoSeelie::NeedStatusDraw() const
 	{
@@ -33,7 +44,7 @@ namespace cheat::feature
 
 	void AutoSeelie::DrawStatus()
 	{
-		ImGui::Text ("AutoSeelie");
+		ImGui::Text("AutoSeelie %s", f_ElectroSeelie ? "+ Electro" : "");
 	}
 
 	AutoSeelie& AutoSeelie::GetInstance()
@@ -47,35 +58,52 @@ namespace cheat::feature
 		auto& manager = game::EntityManager::instance();
 		auto distance = manager.avatar()->distance(entity);
 		float radius = 100.0f;
-	
-		if (entity->name().find("Gear_Seelie") != std::string::npos || entity->name().find("_FireSeelie") != std::string::npos ||
-			entity->name().find("_LitSeelie") != std::string::npos)
+
+		if (entity->name().find("Seelie") != std::string::npos)
 		{
+			if (entity->name().find("ElectricSeelie") != std::string::npos)
+			{
+
+				if (f_ElectroSeelie)
+				{
+					auto EntityGameObject = app::MoleMole_BaseEntity_get_rootGameObject(entity->raw(), nullptr);
+					auto Transform = app::GameObject_GetComponentByName(EntityGameObject, string_to_il2cppi("Transform"), nullptr);
+					auto child = app::Transform_GetChild(reinterpret_cast<app::Transform*>(Transform), 1, nullptr);
+					auto pre_status = app::Component_1_get_gameObject(reinterpret_cast<app::Component_1*>(child), nullptr);
+					auto status = app::GameObject_get_active(reinterpret_cast<app::GameObject*>(pre_status), nullptr);
+
+					if (status)
+					{
+						return false;
+					}
+					return distance <= radius;
+				}
+				return false;
+			}
 			return distance <= radius;
 		}
-		
 		return false;
 	}
 
-    void AutoSeelie::OnGameUpdate()
-    {
-        if (!f_Enabled)
-            return;
+	void AutoSeelie::OnGameUpdate()
+	{
+		if (!f_Enabled)
+			return;
 
 		auto currentTime = util::GetCurrentTimeMillisec();
 		if (currentTime < nextTime)
 			return;
 
-        auto& manager = game::EntityManager::instance();
+		auto& manager = game::EntityManager::instance();
 		auto avatarEntity = manager.avatar();
-        for (const auto& entity : manager.entities())
-        {
-            if (!IsEntityForVac(entity))
-                continue;
+		for (const auto& entity : manager.entities())
+		{
+			if (!IsEntityForVac(entity))
+				continue;
 
-            entity->setRelativePosition(avatarEntity->relativePosition());
-        }
+			entity->setRelativePosition(avatarEntity->relativePosition());
+		}
 		nextTime = currentTime + 1000;
-    }
-	
+	}
+
 }

--- a/cheat-library/src/user/cheat/world/AutoSeelie.h
+++ b/cheat-library/src/user/cheat/world/AutoSeelie.h
@@ -4,7 +4,9 @@
 
 #include <cheat/game/Entity.h>
 #include <cheat/game/filters.h>
+#include <cheat-base/thread-safe.h>
 #include <il2cpp-appdata.h>
+
 
 namespace cheat::feature
 {
@@ -13,6 +15,7 @@ namespace cheat::feature
 	{
 	public:
 		config::Field<config::Toggle<Hotkey>> f_Enabled;
+		config::Field<bool> f_ElectroSeelie;
 
 		static AutoSeelie& GetInstance();
 
@@ -24,10 +27,8 @@ namespace cheat::feature
 
 		void OnGameUpdate();
 	private:
-
-		std::vector<game::IEntityFilter*> m_Filters;
 		AutoSeelie();
-		int nextTime{};
+		SafeValue<int64_t> nextTime;
 		bool IsEntityForVac(cheat::game::Entity* entity);
 	};
 }


### PR DESCRIPTION
Added `ElectroSeelie` support with separate button( If main button not activated - another will not appear.). Fixed `ESP` shacking.
Thanks to @Taiga74164 and @RyujinZX for the help.

https://user-images.githubusercontent.com/84017229/178045903-528457fa-48ed-409c-b760-a9d402b9618b.mp4

![1](https://user-images.githubusercontent.com/84017229/178145513-86240359-375c-4975-ba95-0495f45fd09e.jpg)
![2](https://user-images.githubusercontent.com/84017229/178145512-6514b4e8-88b5-48ed-980a-652a3fe86dfd.jpg)


