### PR TITLE
Add option to duplicate profile

### DIFF
--- a/cheat-base/src/cheat-base/cheat/CheatManagerBase.cpp
+++ b/cheat-base/src/cheat-base/cheat/CheatManagerBase.cpp
@@ -173,6 +173,11 @@ namespace cheat
 			config::RemoveProfile(profileName);
 		if (ImGui::IsItemHovered())
 			ImGui::SetTooltip("Delete");
+
+		if (ImGui::SmallButton("Dupe"))
+			config::DuplicateProfile(profileName);
+		if (ImGui::IsItemHovered())
+			ImGui::SetTooltip("Duplicate Profile");
 	}
 
 	void CheatManagerBase::DrawProfileEntry(const std::string& profileName)

--- a/cheat-base/src/cheat-base/cheat/CheatManagerBase.cpp
+++ b/cheat-base/src/cheat-base/cheat/CheatManagerBase.cpp
@@ -174,6 +174,8 @@ namespace cheat
 		if (ImGui::IsItemHovered())
 			ImGui::SetTooltip("Delete");
 
+		ImGui::SameLine();
+
 		if (ImGui::SmallButton("Dupe"))
 			config::DuplicateProfile(profileName);
 		if (ImGui::IsItemHovered())

--- a/cheat-base/src/cheat-base/config/Config.cpp
+++ b/cheat-base/src/cheat-base/config/Config.cpp
@@ -371,6 +371,27 @@ namespace config
 		ProfileChanged();
 	}
 
+	void DuplicateProfile(const std::string& profileName)
+	{
+		// Find a unique name for the new profile
+		uint32_t counter = 0;
+		std::ostringstream buffer;
+		std::string newProfileName;
+		do
+		{
+			buffer.str(std::string());
+			buffer.clear();
+			counter++;
+			buffer << profileName << " (" << counter << ")";
+			newProfileName = buffer.str();
+		} while (s_Profiles->contains(newProfileName));
+
+		// nlohmann::json copy constructor will take care of duplicating
+		(*s_Profiles)[newProfileName] = (*s_Profiles)[profileName];
+		UpdateProfilesNames();
+		Save();
+	}
+
 	std::vector<std::string> const& GetProfiles()
 	{
 		return s_ProfilesNames;

--- a/cheat-base/src/cheat-base/config/Config.h
+++ b/cheat-base/src/cheat-base/config/Config.h
@@ -63,6 +63,7 @@ namespace config
 	void RemoveProfile(const std::string& profileName);
 	void RenameProfile(const std::string& oldProfileName, const std::string& newProfileName);
 	void ChangeProfile(const std::string& profileName);
+	void DuplicateProfile(const std::string& profileName);
 	std::vector<std::string> const& GetProfiles();
 	std::string const& CurrentProfileName();
 


### PR DESCRIPTION
Hi all,
I've notice we don't have this option yet. I've found myself needing to duplicate profiles sometimes and there's no easy way to do so in-game.
The fix here is pretty simple, since the JSON library we use comes with a built-in copy constructor.

I do need some help with IMGUI though. This is how it looks right now
![Untitled](https://user-images.githubusercontent.com/30932040/179424166-1bc8f89b-c4ba-493d-93c8-36daec624a8c.png)
I'd like all the options to be on one line. If anybody has more experience with IMGUI, give me a hint here.