### PR TITLE
fix interactive map revert latest point completion

### DIFF
--- a/cheat-library/src/user/cheat/imap/InteractiveMap.cpp
+++ b/cheat-library/src/user/cheat/imap/InteractiveMap.cpp
@@ -595,7 +595,7 @@ namespace cheat::feature
 		if (m_CompletedPoints.empty())
 			return;
 
-		PointData* pointData = *m_CompletedPoints.begin();
+		PointData* pointData = *--m_CompletedPoints.end();
 		pointData->completed = false;
 		pointData->completeTimestamp = 0;
 		m_ScenesData[pointData->sceneID].labels[pointData->labelID].completedCount--;


### PR DESCRIPTION
It looks like "unordered_set" is in forward order in memory instead of reverse order