### PR TITLE
Add DescendKey HotKey Setting to NoClip Options

### DIFF
--- a/cheat-library/src/user/cheat/player/NoClip.cpp
+++ b/cheat-library/src/user/cheat/player/NoClip.cpp
@@ -15,6 +15,7 @@ namespace cheat::feature
     NoClip::NoClip() : Feature(),
         NF(f_Enabled,            "No clip",              "NoClip", false),
 		NF(f_NoAnimation,		 "No Animation",		 "NoClip", true),
+		NF(f_DescendKey,		 "Descend HotKey",		 "NoClip", Hotkey(ImGuiKey_ModShift)),
         NF(f_Speed,              "Speed",                "NoClip", 5.5f),
         NF(f_CameraRelative,     "Relative to camera",   "NoClip", true),
 		NF(f_VelocityMode,       "Velocity mode",        "NoClip", false),
@@ -40,6 +41,8 @@ namespace cheat::feature
             "To move, use WASD, Space (go up), and Shift (go down).");
 
 		ConfigWidget("No Animation", f_NoAnimation, "Disables player animations.");
+
+		ConfigWidget("Descend HotKey", f_DescendKey, "Set Key for Descend/Down when NoClip on");
 
 		ConfigWidget("Speed", f_Speed, 0.1f, 2.0f, 100.0f,
 			"No-clip move speed.\n" \
@@ -147,9 +150,9 @@ namespace cheat::feature
 		if (Hotkey(VK_SPACE).IsPressed())
 			dir = dir + avatarEntity->up();
 		
-		if (Hotkey(ImGuiKey_ModShift).IsPressed())
+		if (f_DescendKey.value().IsPressed())
 			dir = dir + avatarEntity->down();
-
+		
 		app::Vector3 prevPos = avatarEntity->relativePosition();
 		if (IsVectorZero(prevPos))
 			return;

--- a/cheat-library/src/user/cheat/player/NoClip.h
+++ b/cheat-library/src/user/cheat/player/NoClip.h
@@ -12,6 +12,7 @@ namespace cheat::feature
 	public:
 		config::Field<config::Toggle<Hotkey>> f_Enabled;
 		config::Field<config::Toggle<Hotkey>> f_NoAnimation;
+		config::Field<Hotkey> f_DescendKey;
 
 		config::Field<float> f_Speed;
 		config::Field<bool> f_CameraRelative;


### PR DESCRIPTION
This will allow you to configure your keys for NoClipping "down" or "descending". By default it continues to use ImGuiKey_ModShift if no setting has been chosen. This is for individuals who do not like using left shift to Go Down.