### PR TITLE
Add FpsPrefix WaterMark to Control showing FPS: <fps>

### DIFF
--- a/cheat-base/src/cheat-base/cheat/CheatManagerBase.cpp
+++ b/cheat-base/src/cheat-base/cheat/CheatManagerBase.cpp
@@ -390,7 +390,12 @@ namespace cheat
 
 		if (ImGui::Begin("FPS", nullptr, flags))
 		{
-			ImGui::Text("FPS: %.1f", ImGui::GetIO().Framerate);
+			if (settings.f_FpsPrefix) {
+				ImGui::Text("FPS: %.1f", ImGui::GetIO().Framerate);
+			}
+			if (!settings.f_FpsPrefix) {
+				ImGui::Text("%.1f", ImGui::GetIO().Framerate);
+			}
 			ImGui::End();
 		}
 	}

--- a/cheat-base/src/cheat-base/cheat/misc/Settings.cpp
+++ b/cheat-base/src/cheat-base/cheat/misc/Settings.cpp
@@ -20,6 +20,7 @@ namespace cheat::feature
 		
 		NF(f_FpsMove, "Move FPS Indicator", "General::FPS", false),
 		NF(f_FpsShow, "Show FPS Indicator", "General::FPS", true),
+		NF(f_FpsPrefix, "Show FPS: Prefix", "General::FPS", true),
 
 		NF(f_NotificationsShow, "Show Notifications", "General::Notify", true), 
 		NF(f_NotificationsDelay, "Notifications Delay", "General::Notify", 500),
@@ -95,6 +96,7 @@ namespace cheat::feature
 		{
 			ConfigWidget(f_FpsShow);
 			ConfigWidget(f_FpsMove, "Allow moving of 'FPS Indicator' window.");
+			ConfigWidget(f_FpsPrefix, "Append \"FPS:\" Prefix");
 		}
 		ImGui::EndGroupPanel();
 

--- a/cheat-base/src/cheat-base/cheat/misc/Settings.h
+++ b/cheat-base/src/cheat-base/cheat/misc/Settings.h
@@ -20,6 +20,7 @@ namespace cheat::feature
 		
 		config::Field<bool> f_FpsShow;
 		config::Field<bool> f_FpsMove;
+		config::Field<bool> f_FpsPrefix;
     
 		config::Field<bool> f_NotificationsShow;
 		config::Field<int> f_NotificationsDelay;


### PR DESCRIPTION
Added a prefix bool option to control whether the FPS: is shown at the front of the FPS display.