### PR TITLE
fixed revert last point completion

### DIFF
--- a/cheat-library/src/user/cheat/imap/InteractiveMap.cpp
+++ b/cheat-library/src/user/cheat/imap/InteractiveMap.cpp
@@ -563,13 +563,13 @@ namespace cheat::feature
 		std::lock_guard _userDataLock(m_UserDataMutex);
 		LOG_WARNING("Complete point at %.0f.", game::EntityManager::instance().avatar()->distance(pointData->levelPosition));
 
-		if (m_CompletedPoints.count(pointData) > 0)
+		if (std::find_if(m_CompletedPoints.begin(), m_CompletedPoints.end(), [=](PointData* data) { return pointData->id == data->id; }) != std::end(m_CompletedPoints))
 			return;
 
 		pointData->completed = true;
 		pointData->completeTimestamp = util::GetCurrentTimeMillisec();
 		m_ScenesData[pointData->sceneID].labels[pointData->labelID].completedCount++;
-		m_CompletedPoints.insert(pointData);
+		m_CompletedPoints.push_back(pointData);
 		
 		SaveCompletedPoints();
 	}
@@ -578,13 +578,14 @@ namespace cheat::feature
 	{
 		std::lock_guard _userDataLock(m_UserDataMutex);
 
-		if (m_CompletedPoints.count(pointData) == 0)
+        auto pointDataIterator = std::find_if(m_CompletedPoints.begin(), m_CompletedPoints.end(), [=](PointData* data) { return pointData->id == data->id; });
+        if (pointDataIterator == m_CompletedPoints.end())
 			return;
 
 		pointData->completed = false;
 		pointData->completeTimestamp = 0;
 		m_ScenesData[pointData->sceneID].labels[pointData->labelID].completedCount--;
-		m_CompletedPoints.erase(pointData);
+		m_CompletedPoints.erase(pointDataIterator);
 
 		SaveCompletedPoints();
 	}
@@ -595,11 +596,12 @@ namespace cheat::feature
 		if (m_CompletedPoints.empty())
 			return;
 
-		PointData* pointData = *--m_CompletedPoints.end();
+        auto pointDataIterator = --m_CompletedPoints.end();
+        PointData* pointData = *pointDataIterator;
 		pointData->completed = false;
 		pointData->completeTimestamp = 0;
 		m_ScenesData[pointData->sceneID].labels[pointData->labelID].completedCount--;
-		m_CompletedPoints.erase(pointData);
+		m_CompletedPoints.erase(pointDataIterator);
 
 		SaveCompletedPoints();
 	}
@@ -916,7 +918,7 @@ namespace cheat::feature
 		}
 
 		auto& point = points[pointID];
-		if (m_CompletedPoints.count(&point) > 0)
+		if (std::find_if(m_CompletedPoints.begin(), m_CompletedPoints.end(), [=](PointData* data) { return point.id == data->id; }) != std::end(m_CompletedPoints))
 		{
 			LOG_WARNING("Completed point %u duplicate.", pointID);
 			return;
@@ -926,7 +928,7 @@ namespace cheat::feature
 		point.completeTimestamp = data["complete_timestamp"];
 		labelData->completedCount++;
 
-		m_CompletedPoints.insert(&point);
+		m_CompletedPoints.push_back(&point);
 	}
 
 	void InteractiveMap::LoadFixedPointData(LabelData* labelData, const nlohmann::json& data)
@@ -1026,6 +1028,7 @@ namespace cheat::feature
 	void InteractiveMap::LoadCompletedPoints()
 	{
 		LoadUserData(f_CompletedPointsJson, &InteractiveMap::LoadCompletedPointData);
+		ReorderCompletedPointDataByTimestamp();
 	}
 
 	void InteractiveMap::SaveCompletedPoints()
@@ -1039,6 +1042,11 @@ namespace cheat::feature
 		ResetUserData(&InteractiveMap::ResetCompletedPointData);
 		m_CompletedPoints.clear();
 	}
+
+    void InteractiveMap::ReorderCompletedPointDataByTimestamp()
+    {
+        m_CompletedPoints.sort([](PointData* a, PointData* b) { return a->completeTimestamp < b->completeTimestamp; });
+    }
 
 	void InteractiveMap::LoadCustomPoints()
 	{

--- a/cheat-library/src/user/cheat/imap/InteractiveMap.cpp
+++ b/cheat-library/src/user/cheat/imap/InteractiveMap.cpp
@@ -595,7 +595,7 @@ namespace cheat::feature
 		if (m_CompletedPoints.empty())
 			return;
 
-		PointData* pointData = *m_CompletedPoints.begin();
+		PointData* pointData = *--m_CompletedPoints.end();
 		pointData->completed = false;
 		pointData->completeTimestamp = 0;
 		m_ScenesData[pointData->sceneID].labels[pointData->labelID].completedCount--;

--- a/cheat-library/src/user/cheat/imap/InteractiveMap.h
+++ b/cheat-library/src/user/cheat/imap/InteractiveMap.h
@@ -146,7 +146,7 @@ namespace cheat::feature
 
 		std::unordered_set<PointData*> m_CustomPoints;
 		std::unordered_set<PointData*> m_FixedPoints;
-		std::unordered_set<PointData*> m_CompletedPoints;
+		std::list<PointData*> m_CompletedPoints;
 
 		std::mutex m_PointMutex;
 		// PointData* m_SelectedPoint;
@@ -182,6 +182,7 @@ namespace cheat::feature
 		void LoadCompletedPointData(LabelData* labelData, const nlohmann::json& data);
 		void SaveCompletedPointData(nlohmann::json& jObject, PointData* point);
 		bool ResetCompletedPointData(LabelData* label, PointData* point);
+		void ReorderCompletedPointDataByTimestamp();
 		
 		void LoadCustomPointData(LabelData* labelData, const nlohmann::json& data);
 		void SaveCustomPointData(nlohmann::json& jObject, PointData* point);


### PR DESCRIPTION
the elements in unordered_set are not sorted in any particular order. so when insert point data , it will insert at begin or end or somewhere. so i changed it to list to make sure the last inserted element must be at the end of the list