### PR TITLE
Fix fast dialogue

### DIFF
--- a/cheat-library/src/user/cheat/world/DialogSkip.cpp
+++ b/cheat-library/src/user/cheat/world/DialogSkip.cpp
@@ -85,6 +85,8 @@ namespace cheat::feature
 
         if (f_FastDialog)
             app::Time_set_timeScale(f_TimeSpeedup, nullptr);
+        else
+            app::Time_set_timeScale(1.0f, nullptr);
 
         bool isImportant = false;
         if (f_ExcludeImportant)


### PR DESCRIPTION
Hi all,
I've noticed that the cheat "fast dialogue" has a small bug:
When the player engages in a conversation with fast dialogue option enabled, the timescale of the game will be increased to 5 (or whatever speed option the user uses). Now, if I disable the cheat **while still in the dialogue menu** (this mostly happens for NPCs like Tubby, Katherine etc.) then the timescale is not reset back to 1. The timescale persists until the player exits the dialogue menu.

I personally find this a bit annoying and dangerous since you might be stuck in some of these menus for quite some time (say, claiming journey rewards and sending your characters back on other journeys, or claiming furniture from tubby then deciding what to build next). With the timescale at 5 for prolonged periods of time, I think this increases the chances for a ban.

So, my solution is quite simple: if you are in a dialogue menu and f_FastDialogue is disabled, then set the timescale to 1