### PR TITLE
Add GameSpeed Option to Fix Issue #280

### DIFF
--- a/cheat-library/src/user/cheat/world/DialogSkip.h
+++ b/cheat-library/src/user/cheat/world/DialogSkip.h
@@ -14,6 +14,9 @@ namespace cheat::feature
 		config::Field<config::Toggle<Hotkey>> f_FastDialog;
 		config::Field<config::Toggle<Hotkey>> f_CutsceneUSM;
 		config::Field<float> f_TimeSpeedup;
+		config::Field<bool> f_GameSpeedEnabled;
+		config::Field<Hotkey> f_GameSpeedKey;
+		config::Field<float> f_GameSpeedVal;
 
 		static DialogSkip& GetInstance();
 
@@ -23,6 +26,7 @@ namespace cheat::feature
 		virtual bool NeedStatusDraw() const override;
 		void DrawStatus() override;
 
+		void OnGameUpdate();
 		void OnCutScenePageUpdate(app::InLevelCutScenePageContext* context);
 
 	private:


### PR DESCRIPTION
Add's GameSpeed Option in Dialog Skip Feature. When HotKey pressed will speed up game until HotKey released then set back to 1.0f.