### PR TITLE
RapidFire Changes

### DIFF
--- a/cheat-library/src/appdata/il2cpp-functions.h
+++ b/cheat-library/src/appdata/il2cpp-functions.h
@@ -56,6 +56,7 @@ DO_APP_FUNC(0x02DB4680, void, MoleMole_ActorAbilityPlugin_AddDynamicFloatWithRan
 // Rapid fire
 DO_APP_FUNC(0x017B1D50, void, MoleMole_LCBaseCombat_DoHitEntity, (LCBaseCombat* __this, uint32_t targetID, AttackResult* attackResult, bool ignoreCheckCanBeHitInMP, MethodInfo* method));
 DO_APP_FUNC(0x019DDF40, void, MoleMole_Formula_CalcAttackResult, (CombatProperty* attackCombatProperty, CombatProperty* defenseCombatProperty, AttackResult* attackResult, BaseEntity* attackerEntity, BaseEntity* attackeeEntity, MethodInfo* method));
+DO_APP_FUNC(0x0106D020, void, MoleMole_VCAnimatorEvent_HandleProcessItem, (MoleMole_VCAnimatorEvent* __this, MoleMole_VCAnimatorEvent_MoleMole_VCAnimatorEvent_AnimatorEventPatternProcessItem* processItem, AnimatorStateInfo processStateInfo, MoleMole_VCAnimatorEvent_MoleMole_VCAnimatorEvent_TriggerMode__Enum mode, MethodInfo* method));
 
 
 // World cheats

--- a/cheat-library/src/appdata/il2cpp-types.h
+++ b/cheat-library/src/appdata/il2cpp-types.h
@@ -11998,6 +11998,61 @@ namespace app {
         struct MoleMole_ActorAbilityPlugin__Fields fields;
     };
 
+    struct MoleMole_VCAnimatorEvent__Fields {
+        struct VCBase__Fields _;
+        struct Animator* _animator;
+        struct Action_1_MoleMole_AnimatorParameterEntry_* onUserInputControllerChanged;
+        struct Action_4_Int32_UnityEngine_AnimatorStateInfo_UnityEngine_AnimatorStateInfo_MoleMole_AnimatorStateChangeExtra_* onAnimatorStateTransitionFinish;
+        struct Dictionary_2_System_Int32_Dictionary_2_System_Int32_List_1_System_Int32_* _activeAnimatorEventPatterns;
+        struct Dictionary_2_System_Int32_System_Int32_* _filterOldPattern2newPattern;
+        struct Action_2_Int32_Single_* processNormalizedTimeActions;
+        struct Queue_1_MoleMole_CompensateDiffInfo_* authorityEventQueue;
+        struct Queue_1_MoleMole_CompensateDiffInfo_* remoteEventQueue;
+        struct MoleMole_VCMoveData* _moveData;
+        struct MoleMole_VCSyncAnimator* _vcSyncAnimator;
+        int32_t MAX_ALLOW_COMPENSATE_TIME;
+        struct List_1_System_Int32_* _layerIndexes;
+        struct Dictionary_2_System_Int32_MoleMole_VCAnimatorEvent_MoleMole_VCAnimatorEvent_AnimatorLayerItem_* _layerItems;
+    };
+
+    struct MoleMole_VCAnimatorEvent {
+        struct MoleMole_VCAnimatorEvent__Class* klass;
+        MonitorData* monitor;
+        struct MoleMole_VCAnimatorEvent__Fields fields;
+    };
+
+    struct AnimatorStateInfo {
+        int32_t m_Name;
+        int32_t m_Path;
+        int32_t m_FullPath;
+        float m_NormalizedTime;
+        float m_Length;
+        float m_Speed;
+        float m_SpeedMultiplier;
+        int32_t m_Tag;
+        int32_t m_Loop;
+    };
+    
+    struct __declspec(align(8)) MoleMole_VCAnimatorEvent_MoleMole_VCAnimatorEvent_AnimatorEventPatternProcessItem__Fields {
+        struct List_1_System_Int32_* patterns;
+        struct AnimatorStateInfo stateInfo;
+        float lastTime;
+    };
+
+    struct MoleMole_VCAnimatorEvent_MoleMole_VCAnimatorEvent_AnimatorEventPatternProcessItem {
+        struct MoleMole_VCAnimatorEvent_MoleMole_VCAnimatorEvent_AnimatorEventPatternProcessItem__Class* klass;
+        MonitorData* monitor;
+        struct MoleMole_VCAnimatorEvent_MoleMole_VCAnimatorEvent_AnimatorEventPatternProcessItem__Fields fields;
+    };
+
+    enum class MoleMole_VCAnimatorEvent_MoleMole_VCAnimatorEvent_TriggerMode__Enum : int32_t {
+        NormalTrigger = 0x00000000,
+        ForceTriggerOnEnter = 0x00000001,
+        ForceTriggerOnExitImediately = 0x00000002,
+        ForceTriggerOnExitTransition = 0x00000003,
+        ForceTriggerOnExitTransitionFinish = 0x00000004,
+    };
+
 #if !defined(_GHIDRA_) && !defined(_IDA_)
 }
 #endif

--- a/cheat-library/src/user/cheat/player/RapidFire.cpp
+++ b/cheat-library/src/user/cheat/player/RapidFire.cpp
@@ -6,41 +6,41 @@
 #include <cheat/game/util.h>
 #include <cheat/game/filters.h>
 
-namespace cheat::feature 
+namespace cheat::feature
 {
 	static void LCBaseCombat_DoHitEntity_Hook(app::LCBaseCombat* __this, uint32_t targetID, app::AttackResult* attackResult,
 		bool ignoreCheckCanBeHitInMP, MethodInfo* method);
 
-    RapidFire::RapidFire() : Feature(),
-        NF(f_Enabled,			"Attack Multiplier",	"RapidFire", false),
-		NF(f_MultiHit,			"Multi-hit",			"RapidFire", false),
-        NF(f_Multiplier,		"Hit Multiplier",		"RapidFire", 2),
-        NF(f_OnePunch,			"One Punch Mode",		"RapidFire", false),
-		NF(f_Randomize,			"Randomize",			"RapidFire", false),
-		NF(f_minMultiplier,		"Min Multiplier",		"RapidFire", 1),
-		NF(f_maxMultiplier,		"Max Multiplier",		"RapidFire", 3),
-		NF(f_MultiTarget,		"Multi-target",			"RapidFire", false),
-		NF(f_MultiTargetRadius, "Multi-target Radius",	"RapidFire", 20.0f)
-    {
+	RapidFire::RapidFire() : Feature(),
+		NF(f_Enabled, "Attack Multiplier", "RapidFire", false),
+		NF(f_MultiHit, "Multi-hit", "RapidFire", false),
+		NF(f_Multiplier, "Hit Multiplier", "RapidFire", 2),
+		NF(f_OnePunch, "One Punch Mode", "RapidFire", false),
+		NF(f_Randomize, "Randomize", "RapidFire", false),
+		NF(f_minMultiplier, "Min Multiplier", "RapidFire", 1),
+		NF(f_maxMultiplier, "Max Multiplier", "RapidFire", 3),
+		NF(f_MultiTarget, "Multi-target", "RapidFire", false),
+		NF(f_MultiTargetRadius, "Multi-target Radius", "RapidFire", 20.0f)
+	{
 		HookManager::install(app::MoleMole_LCBaseCombat_DoHitEntity, LCBaseCombat_DoHitEntity_Hook);
-    }
+	}
 
-    const FeatureGUIInfo& RapidFire::GetGUIInfo() const
-    {
-        static const FeatureGUIInfo info{ "Attack Effects", "Player", true };
-        return info;
-    }
+	const FeatureGUIInfo& RapidFire::GetGUIInfo() const
+	{
+		static const FeatureGUIInfo info{ "Attack Effects", "Player", true };
+		return info;
+	}
 
-    void RapidFire::DrawMain()
-    {
+	void RapidFire::DrawMain()
+	{
 		ConfigWidget("Enabled", f_Enabled, "Enables attack multipliers. Need to choose a mode to work.");
 		ImGui::SameLine();
 		ImGui::TextColored(ImColor(255, 165, 0, 255), "Choose any or both modes below.");
 
 		ConfigWidget("Multi-hit Mode", f_MultiHit, "Enables multi-hit.\n" \
-            "Multiplies your attack count.\n" \
-            "This is not well tested, and can be detected by anticheat.\n" \
-            "Not recommended to be used with main accounts or used with high values.\n" \
+			"Multiplies your attack count.\n" \
+			"This is not well tested, and can be detected by anticheat.\n" \
+			"Not recommended to be used with main accounts or used with high values.\n" \
 			"Known issues with certain multi-hit attacks, e.g. Xiao E, Ayaka CA, etc.");
 
 		ImGui::Indent();
@@ -73,20 +73,20 @@ namespace cheat::feature
 			"If multi-hit is off and there are still multiple numbers on a single target, check the Entity Manager in the Debug section to see if there are invisible entities.\n" \
 			"This can cause EXTREME lag and quick bans if used with multi-hit. You are warned."
 		);
-	
+
 		ImGui::Indent();
 		ConfigWidget("Radius (m)", f_MultiTargetRadius, 0.1f, 5.0f, 50.0f, "Radius to check for valid targets.");
 		ImGui::Unindent();
-    }
+	}
 
-    bool RapidFire::NeedStatusDraw() const
-{
-        return f_Enabled && (f_MultiHit || f_MultiTarget);
-    }
+	bool RapidFire::NeedStatusDraw() const
+	{
+		return f_Enabled && (f_MultiHit || f_MultiTarget);
+	}
 
-    void RapidFire::DrawStatus() 
-    {
-		if (f_MultiHit) 
+	void RapidFire::DrawStatus()
+	{
+		if (f_MultiHit)
 		{
 			if (f_Randomize)
 				ImGui::Text("Multi-Hit Random[%d|%d]", f_minMultiplier.value(), f_maxMultiplier.value());
@@ -97,20 +97,20 @@ namespace cheat::feature
 		}
 		if (f_MultiTarget)
 			ImGui::Text("Multi-Target [%.01fm]", f_MultiTargetRadius.value());
-    }
+	}
 
-    RapidFire& RapidFire::GetInstance()
-    {
-        static RapidFire instance;
-        return instance;
-    }
+	RapidFire& RapidFire::GetInstance()
+	{
+		static RapidFire instance;
+		return instance;
+	}
 
 
 	int RapidFire::CalcCountToKill(float attackDamage, uint32_t targetID)
 	{
 		if (attackDamage == 0)
 			return f_Multiplier;
-		
+
 		auto& manager = game::EntityManager::instance();
 		auto targetEntity = manager.entity(targetID);
 		if (targetEntity == nullptr)
@@ -165,10 +165,10 @@ namespace cheat::feature
 			entity = game::Entity(app::MoleMole_GadgetEntity_GetOwnerEntity(reinterpret_cast<app::GadgetEntity*>(entity.raw()), nullptr));
 			if (entity.runtimeID() == avatarID)
 				return true;
-		} 
+		}
 
 		return false;
-		
+
 	}
 
 	bool IsAttackByAvatar(game::Entity& attacker)
@@ -183,6 +183,20 @@ namespace cheat::feature
 		return attackerID == avatarID || IsAvatarOwner(attacker);
 	}
 
+	bool IsConfigByAvatar(game::Entity& attacker)
+	{
+		if (attacker.raw() == nullptr)
+			return false;
+
+		auto& manager = game::EntityManager::instance();
+		auto avatarID = manager.avatar()->raw()->fields._configID_k__BackingField;
+		auto attackerID = attacker.raw()->fields._configID_k__BackingField;
+		// Taiga#5555: IDs can be found in ConfigAbility_Avatar_*.json or GadgetExcelConfigData.json
+		bool bulletID = attackerID >= 40000160 && attackerID <= 41069999;
+
+		return avatarID == attackerID || bulletID;
+	}
+
 	bool IsValidByFilter(game::Entity* entity)
 	{
 		if (game::filters::combined::OrganicTargets.IsValid(entity) ||
@@ -192,7 +206,7 @@ namespace cheat::feature
 			game::filters::puzzle::LargeRockPile.IsValid(entity) ||
 			game::filters::puzzle::SmallRockPile.IsValid(entity))
 			return true;
-		return false;		 
+		return false;
 	}
 
 	// Raises when any entity do hit event.
@@ -203,7 +217,7 @@ namespace cheat::feature
 	{
 		auto attacker = game::Entity(__this->fields._._._entity);
 		RapidFire& rapidFire = RapidFire::GetInstance();
-		if (!IsAttackByAvatar(attacker) || !rapidFire.f_Enabled)
+		if (!IsConfigByAvatar(attacker) || !IsAttackByAvatar(attacker) || !rapidFire.f_Enabled)
 			return CALL_ORIGIN(LCBaseCombat_DoHitEntity_Hook, __this, targetID, attackResult, ignoreCheckCanBeHitInMP, method);
 
 		auto& manager = game::EntityManager::instance();
@@ -243,7 +257,8 @@ namespace cheat::feature
 				int attackCount = rapidFire.GetAttackCount(__this, entity->runtimeID(), attackResult);
 				for (int i = 0; i < attackCount; i++)
 					CALL_ORIGIN(LCBaseCombat_DoHitEntity_Hook, __this, entity->runtimeID(), attackResult, ignoreCheckCanBeHitInMP, method);
-			} else CALL_ORIGIN(LCBaseCombat_DoHitEntity_Hook, __this, entity->runtimeID(), attackResult, ignoreCheckCanBeHitInMP, method);
+			}
+			else CALL_ORIGIN(LCBaseCombat_DoHitEntity_Hook, __this, entity->runtimeID(), attackResult, ignoreCheckCanBeHitInMP, method);
 		}
 	}
 }

--- a/cheat-library/src/user/cheat/player/RapidFire.cpp
+++ b/cheat-library/src/user/cheat/player/RapidFire.cpp
@@ -267,9 +267,9 @@ namespace cheat::feature
 			if (rapidFire.f_MultiHit) {
 				int attackCount = rapidFire.GetAttackCount(__this, entity->runtimeID(), attackResult);
 				for (int i = 0; i < attackCount; i++)
-					CALL_ORIGIN(LCBaseCombat_DoHitEntity_Hook, __this, entity->runtimeID(), attackResult, ignoreCheckCanBeHitInMP, method);
+					app::MoleMole_LCBaseCombat_FireBeingHitEvent(__this, entity->runtimeID(), attackResult, method);
 			}
-			else CALL_ORIGIN(LCBaseCombat_DoHitEntity_Hook, __this, entity->runtimeID(), attackResult, ignoreCheckCanBeHitInMP, method);
+			else app::MoleMole_LCBaseCombat_FireBeingHitEvent(__this, entity->runtimeID(), attackResult, method);
 		}
 	}
 

--- a/cheat-library/src/user/cheat/player/RapidFire.cpp
+++ b/cheat-library/src/user/cheat/player/RapidFire.cpp
@@ -281,7 +281,7 @@ namespace cheat::feature
 		RapidFire& rapidFire = RapidFire::GetInstance();
 
 		if (rapidFire.f_MultiAnimation && IsAttackByAvatar(attacker))
-			processItem->fields.lastTime = -1;
+			processItem->fields.lastTime = 0;
 
 		CALL_ORIGIN(VCAnimatorEvent_HandleProcessItem_Hook, __this, processItem, processStateInfo, mode, method);
 	}

--- a/cheat-library/src/user/cheat/player/RapidFire.h
+++ b/cheat-library/src/user/cheat/player/RapidFire.h
@@ -19,6 +19,7 @@ namespace cheat::feature
 		config::Field<int> f_maxMultiplier;
 		config::Field<config::Toggle<Hotkey>> f_MultiTarget;
 		config::Field<float> f_MultiTargetRadius;
+		config::Field<config::Toggle<Hotkey>> f_MultiAnimation;
 
 		static RapidFire& GetInstance();
 


### PR DESCRIPTION
## Requires testing
- [x] Fixed #73 
- [x] Fixed #98 
- [x] Fixed #10 
- [x] Added Multi-Animation Rapid Fire [Request from Discord](https://discord.com/channels/440536354544156683/986013153437548594/1004329740393521254)

Basically filtered it the same way I did for XYZ. If you want to debug you can check ``[rbx]`` which is equivalent to ``MoleMole_BaseEntity`` in ``MoleMole_LCBaseCombat_DoHitEntity`` function.

Ayaka's charged attack should be fixed with this method. **Polearm character's charged attack still needs to be fixed.**
