### PR TITLE
Add GameSpeed FEAT and Destroy Special Objects/Chests

### DIFF
--- a/cheat-library/cheat-library.vcxproj
+++ b/cheat-library/cheat-library.vcxproj
@@ -100,6 +100,7 @@
     <ClInclude Include="src\user\cheat\world\DialogSkip.h" />
     <ClInclude Include="src\user\cheat\world\DumbEnemies.h" />
     <ClInclude Include="src\user\cheat\world\FreezeEnemies.h" />
+    <ClInclude Include="src\user\cheat\world\GameSpeed.h" />
     <ClInclude Include="src\user\cheat\world\KillAura.h" />
     <ClInclude Include="src\user\cheat\world\MobVacuum.h" />
     <ClInclude Include="src\user\cheat\world\OpenTeamImmediately.h" />
@@ -193,6 +194,7 @@
     <ClCompile Include="src\user\cheat\world\DialogSkip.cpp" />
     <ClCompile Include="src\user\cheat\world\DumbEnemies.cpp" />
     <ClCompile Include="src\user\cheat\world\FreezeEnemies.cpp" />
+    <ClCompile Include="src\user\cheat\world\GameSpeed.cpp" />
     <ClCompile Include="src\user\cheat\world\KillAura.cpp" />
     <ClCompile Include="src\user\cheat\world\MobVacuum.cpp" />
     <ClCompile Include="src\user\cheat\world\OpenTeamImmediately.cpp" />

--- a/cheat-library/cheat-library.vcxproj.filters
+++ b/cheat-library/cheat-library.vcxproj.filters
@@ -264,6 +264,9 @@
     <ClInclude Include="src\user\cheat\world\OpenTeamImmediately.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="src\user\cheat\world\GameSpeed.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Font Include="res\Ruda-Bold.ttf" />
@@ -484,6 +487,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="src\user\cheat\world\OpenTeamImmediately.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="src\user\cheat\world\GameSpeed.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/cheat-library/src/user/cheat/cheat.cpp
+++ b/cheat-library/src/user/cheat/cheat.cpp
@@ -31,6 +31,7 @@
 #include <cheat/world/FakeTime.h>
 #include <cheat/world/AutoSeelie.h>
 #include <cheat/world/VacuumLoot.h>
+#include <cheat/world/GameSpeed.h>
 
 #include <cheat/teleport/ChestTeleport.h>
 #include <cheat/teleport/MapTeleport.h>
@@ -116,6 +117,7 @@ namespace cheat
 
 			FEAT_INST(AutoFish),
 			FEAT_INST(AutoCook),
+			FEAT_INST(GameSpeed),
 
 			FEAT_INST(CustomWeather),
 

--- a/cheat-library/src/user/cheat/game/filters.cpp
+++ b/cheat-library/src/user/cheat/game/filters.cpp
@@ -367,7 +367,11 @@ namespace cheat::game::filters
 			plant::MistFlowerCorolla,
 			plant::FlamingFlowerStamen
 		};
-
+		SimpleFilter BreakableObjects = {
+			puzzle::AncientRime,
+			puzzle::LargeRockPile,
+			puzzle::SmallRockPile
+		};
 		WhitelistFilter Doodads = {
 			EntityType__Enum_1::Gadget,
 			{

--- a/cheat-library/src/user/cheat/game/filters.h
+++ b/cheat-library/src/user/cheat/game/filters.h
@@ -342,6 +342,7 @@ namespace cheat::game::filters
 		extern SimpleFilter Chests;
 		extern SimpleFilter Ores;
 		extern SimpleFilter PlantDestroy;
+		extern SimpleFilter BreakableObjects;
 		extern WhitelistFilter Doodads;
 		extern SimpleFilter Animals;
 		extern SimpleFilter AnimalDrop;

--- a/cheat-library/src/user/cheat/world/AutoDestroy.cpp
+++ b/cheat-library/src/user/cheat/world/AutoDestroy.cpp
@@ -20,6 +20,8 @@ namespace cheat::feature
 		NF(f_DestroyShields, "Destroy Shields", "AutoDestroy", false),
 		NF(f_DestroyDoodads, "Destroy Doodads", "AutoDestroy", false),
 		NF(f_DestroyPlants, "Destroy Plants", "AutoDestroy", false),
+		NF(f_DestroySpecialObjects, "Destroy Special Objects", "AutoDestroy", false),
+		NF(f_DestroySpecialChests, "Destroy Special Chests", "AutoDestroy", false),
 		NF(f_Range, "Range", "AutoDestroy", 10.0f)
 	{
 		HookManager::install(app::MoleMole_LCAbilityElement_ReduceModifierDurability, LCAbilityElement_ReduceModifierDurability_Hook);
@@ -46,6 +48,12 @@ namespace cheat::feature
 		ImGui::SameLine();
 		ImGui::TextColored(ImColor(255, 165, 0, 255), "Extremely risky!");
 		ConfigWidget("Plants", f_DestroyPlants, "Dandelion Seeds, Sakura Bloom, etc.");
+		ConfigWidget("Special Objects", f_DestroySpecialObjects, "Destroy Ancient Rime, Large and Small Rock Piles");
+		ImGui::SameLine();
+		ImGui::TextColored(ImColor(255, 165, 0, 255), "Risk Unknown!");
+		ConfigWidget("Special Chests", f_DestroySpecialChests, "Destroy Chests with Brambles, Frozen, or In Rocks");
+		ImGui::SameLine();
+		ImGui::TextColored(ImColor(255, 165, 0, 255), "Risk Unknown!");
 		ImGui::Unindent();
 		ConfigWidget("Range (m)", f_Range, 0.1f, 1.0f, 15.0f);
 	}
@@ -57,13 +65,15 @@ namespace cheat::feature
 
 	void AutoDestroy::DrawStatus()
 	{
-		ImGui::Text("Destroy [%.01fm%s%s%s%s%s]",
+		ImGui::Text("Destroy [%.01fm%s%s%s%s%s%s%s]",
 			f_Range.value(),
-			f_DestroyOres || f_DestroyShields || f_DestroyDoodads || f_DestroyPlants ? "|" : "",
+			f_DestroyOres || f_DestroyShields || f_DestroyDoodads || f_DestroyPlants || f_DestroySpecialObjects || f_DestroySpecialChests ? "|" : "",
 			f_DestroyOres ? "O" : "",
 			f_DestroyShields ? "S" : "",
 			f_DestroyDoodads ? "D" : "",
-			f_DestroyPlants ? "P" : "");
+			f_DestroyPlants ? "P" : "",
+			f_DestroySpecialObjects ? "SO" : "",
+			f_DestroySpecialChests ? "SC" : "");
 	}
 
 	AutoDestroy& AutoDestroy::GetInstance()
@@ -99,9 +109,11 @@ namespace cheat::feature
 				(autoDestroy.f_DestroyOres && game::filters::combined::Ores.IsValid(manager.entity(entity))) ||
 				(autoDestroy.f_DestroyDoodads && (game::filters::combined::Doodads.IsValid(manager.entity(entity)) || game::filters::chest::SBramble.IsValid(manager.entity(entity)))) ||
 				(autoDestroy.f_DestroyShields && !game::filters::combined::MonsterBosses.IsValid(manager.entity(entity)) && (
-					game::filters::combined::MonsterShielded.IsValid(manager.entity(entity)) ||									// For shields attached to monsters, e.g. abyss mage shields.
-					game::filters::combined::MonsterEquips.IsValid(manager.entity(entity)))) ||									// For shields/weapons equipped by monsters, e.g. rock shield.
-					(autoDestroy.f_DestroyPlants && game::filters::combined::PlantDestroy.IsValid(manager.entity(entity)))		// For plants e.g dandelion seeds.
+					game::filters::combined::MonsterShielded.IsValid(manager.entity(entity)) ||											// For shields attached to monsters, e.g. abyss mage shields.
+					game::filters::combined::MonsterEquips.IsValid(manager.entity(entity)))) ||											// For shields/weapons equipped by monsters, e.g. rock shield.
+					(autoDestroy.f_DestroyPlants && game::filters::combined::PlantDestroy.IsValid(manager.entity(entity))) ||			// For plants e.g dandelion seeds.
+				(autoDestroy.f_DestroySpecialObjects && game::filters::combined::BreakableObjects.IsValid(manager.entity(entity))) ||	// For Breakable Objects e.g Ancient Rime, Large and Small Rock Piles.
+				(autoDestroy.f_DestroySpecialChests && game::filters::combined::Chests.IsValid(manager.entity(entity)))					// For Special Chests e.g Brambles, Frozen, Encased in Rock.
 				)
 			)
 		{

--- a/cheat-library/src/user/cheat/world/AutoDestroy.h
+++ b/cheat-library/src/user/cheat/world/AutoDestroy.h
@@ -13,6 +13,8 @@ namespace cheat::feature
 		config::Field<config::Toggle<Hotkey>> f_DestroyShields;
 		config::Field<config::Toggle<Hotkey>> f_DestroyDoodads;
 		config::Field<config::Toggle<Hotkey>> f_DestroyPlants;
+		config::Field<config::Toggle<Hotkey>> f_DestroySpecialObjects;
+		config::Field<config::Toggle<Hotkey>> f_DestroySpecialChests;
 		config::Field<float> f_Range;
 
 		static AutoDestroy& GetInstance();

--- a/cheat-library/src/user/cheat/world/GameSpeed.cpp
+++ b/cheat-library/src/user/cheat/world/GameSpeed.cpp
@@ -1,0 +1,76 @@
+#include "pch-il2cpp.h"
+#include "GameSpeed.h"
+
+#include <helpers.h>
+#include <cheat/events.h>
+#include <cheat/game/EntityManager.h>
+
+namespace cheat::feature
+{
+    GameSpeed::GameSpeed() : Feature(),
+        NF(f_Enabled, "GameSpeed Enabled", "GameSpeed", false),
+        NF(f_HotKey, "GameSpeed HotKey", "GameSpeed", Hotkey(ImGuiKey_CapsLock)),
+        NF(f_Speed, "GameSpeed Multiplier", "GameSpeed", 5.0f)
+    {
+        events::GameUpdateEvent += MY_METHOD_HANDLER(GameSpeed::OnGameUpdate);
+    }
+
+    const FeatureGUIInfo& GameSpeed::GetGUIInfo() const
+    {
+        static const FeatureGUIInfo info{ "GameSpeed", "World", true };
+        return info;
+    }
+
+    void GameSpeed::DrawMain()
+    {
+        ConfigWidget("GameSpeed Enabled", f_Enabled, "Speeds Up Game with HotKey");
+        if (f_Enabled)
+        {
+            ConfigWidget("GameSpeed HotKey", f_HotKey, "Set GameSpeed HotKey");
+            ConfigWidget(f_Speed, 1.0f, 1.0f, 15.0f, "Set GameSpeed Multiplier\n" \
+			"Multiplier is a multiplicity of 1.0f for how much faster the game should run.\n" \
+			"Do NOT Use this in the Open World, only use in Menus/etc, VERY DANGEROUS!"
+			);
+        }
+    }
+
+    bool GameSpeed::NeedStatusDraw() const
+    {
+        return f_Enabled;
+    }
+
+    void GameSpeed::DrawStatus()
+    {
+		ImGui::Text("GameSpeed");
+    }
+
+    GameSpeed& GameSpeed::GetInstance()
+    {
+        static GameSpeed instance;
+        return instance;
+    }
+
+    // Raised On Game Update
+    void GameSpeed::OnGameUpdate()
+    {
+        static bool isSpeed = false;
+        if (f_Enabled ? f_HotKey.value().IsPressed() : Hotkey(ImGuiKey_CapsLock).IsPressed() && !isSpeed)
+        {
+            isSpeed = true;
+            float currentSpeed = app::Time_get_timeScale(nullptr);
+            if (currentSpeed == 1.0f)
+                app::Time_set_timeScale(f_Speed, nullptr);
+        }
+
+        if (f_Enabled ? !f_HotKey.value().IsPressed() : !Hotkey(ImGuiKey_CapsLock).IsPressed() && isSpeed)
+        {
+            isSpeed = false;
+            float currentSpeed = app::Time_get_timeScale(nullptr);
+            if (currentSpeed != 1.0f)
+                app::Time_set_timeScale(1.0f, nullptr);
+        }
+        // float gameSpeed = app::Time_get_timeScale(nullptr);
+        //LOG_DEBUG("GameSpeed: %f Enabled: %d Value: %f Key: %s", gameSpeed, f_GameSpeedEnabled, f_GameSpeedVal, f_GameSpeedKey);
+    }
+}
+

--- a/cheat-library/src/user/cheat/world/GameSpeed.cpp
+++ b/cheat-library/src/user/cheat/world/GameSpeed.cpp
@@ -54,20 +54,26 @@ namespace cheat::feature
     void GameSpeed::OnGameUpdate()
     {
         static bool isSpeed = false;
-        if (f_Enabled ? f_HotKey.value().IsPressed() : Hotkey(ImGuiKey_CapsLock).IsPressed() && !isSpeed)
+        if (f_Enabled ? f_HotKey.value().IsPressed() : Hotkey(ImGuiKey_CapsLock).IsPressed())
         {
-            isSpeed = true;
-            float currentSpeed = app::Time_get_timeScale(nullptr);
-            if (currentSpeed == 1.0f)
-                app::Time_set_timeScale(f_Speed, nullptr);
+            if (!isSpeed)
+            {
+                isSpeed = true;
+                float currentSpeed = app::Time_get_timeScale(nullptr);
+                if (currentSpeed == 1.0f)
+                    app::Time_set_timeScale(f_Speed, nullptr);
+            }
         }
 
-        if (f_Enabled ? !f_HotKey.value().IsPressed() : !Hotkey(ImGuiKey_CapsLock).IsPressed() && isSpeed)
+        if (f_Enabled ? !f_HotKey.value().IsPressed() : !Hotkey(ImGuiKey_CapsLock).IsPressed())
         {
-            isSpeed = false;
-            float currentSpeed = app::Time_get_timeScale(nullptr);
-            if (currentSpeed != 1.0f)
-                app::Time_set_timeScale(1.0f, nullptr);
+            if (isSpeed)
+            {
+                isSpeed = false;
+                float currentSpeed = app::Time_get_timeScale(nullptr);
+                if (currentSpeed != 1.0f)
+                    app::Time_set_timeScale(1.0f, nullptr);
+            }
         }
         // float gameSpeed = app::Time_get_timeScale(nullptr);
         //LOG_DEBUG("GameSpeed: %f Enabled: %d Value: %f Key: %s", gameSpeed, f_GameSpeedEnabled, f_GameSpeedVal, f_GameSpeedKey);

--- a/cheat-library/src/user/cheat/world/GameSpeed.h
+++ b/cheat-library/src/user/cheat/world/GameSpeed.h
@@ -1,0 +1,27 @@
+#pragma once
+#include <cheat-base/cheat/Feature.h>
+#include <cheat-base/config/config.h>
+
+namespace cheat::feature
+{
+
+	class GameSpeed : public Feature
+	{
+	public:
+		config::Field<config::Toggle<Hotkey>> f_Enabled;
+		config::Field<Hotkey> f_HotKey;
+		config::Field<float> f_Speed;
+
+		static GameSpeed& GetInstance();
+
+		const FeatureGUIInfo& GetGUIInfo() const override;
+		void DrawMain() override;
+
+		virtual bool NeedStatusDraw() const override;
+		void DrawStatus() override;
+
+		void OnGameUpdate();
+	private:
+		GameSpeed();
+	};
+}


### PR DESCRIPTION
Feature lets you configure a HotKey and a TimeScale, when HotKey is held it speeds up the game by the TimeScale.

The risk with this is mostly within using it in the open world. Menu's should be safe, open world can't be determined. Would recommend against it.