### PR TITLE
Small changes for people who use akebi to shoot video

### DIFF
--- a/cheat-library/src/user/cheat/visuals/FreeCamera.cpp
+++ b/cheat-library/src/user/cheat/visuals/FreeCamera.cpp
@@ -1,6 +1,7 @@
 #include "pch-il2cpp.h"
 #include "FreeCamera.h"
 
+#include <math.h>
 #include <helpers.h>
 #include <cheat/events.h>
 #include <cheat/game/EntityManager.h>
@@ -18,7 +19,7 @@ namespace cheat::feature
 	app::Component_1* mainCam_Camera;
 	app::Vector3 targetPosition;
 	app::Vector3 smoothPosition;
-	float smoothFOV;
+	float smoothFOV, focalLength = 0;
 	bool isEnabled = false;
 
 	FreeCamera::FreeCamera() : Feature(),
@@ -31,7 +32,10 @@ namespace cheat::feature
 		NF(f_RollSpeed, "Roll Speed", "Visuals::FreeCamera", 1.0f),
 		NF(f_FOVSpeed, "FOV Speed", "Visuals::FreeCamera", 0.1f),
 		NF(f_FOV, "Field of View", "Visuals::FreeCamera", 45.0f),
-		NF(f_Smoothing, "Smoothing", "Visuals::FreeCamera", 1.0f),
+		NF(f_MovSmoothing, "Movement Smoothing", "Visuals::FreeCamera", 1.0f),
+		NF(f_LookSmoothing, "Look Smoothing", "Visuals::FreeCamera", 1.0f),
+		NF(f_RollSmoothing, "Roll Smoothing", "Visuals::FreeCamera", 1.0f),
+		NF(f_FovSmoothing, "FOV Smoothing", "Visuals::FreeCamera", 1.0f),
 		NF(f_Forward, "Forward", "Visuals::FreeCamera", Hotkey('W')),
 		NF(f_Backward, "Backward", "Visuals::FreeCamera", Hotkey('S')),
 		NF(f_Left, "Left", "Visuals::FreeCamera", Hotkey('A')),
@@ -74,8 +78,15 @@ namespace cheat::feature
 				ConfigWidget("Look Sensitivity", f_LookSens, 0.01f, 0.01f, 100.0f);
 				ConfigWidget("Roll Speed", f_RollSpeed, 0.01f, 0.01f, 100.0f);
 				ConfigWidget("FOV Speed", f_FOVSpeed, 0.01f, 0.01f, 100.0f);
-				ConfigWidget("Field of View", f_FOV, 0.1f, 0.01f, 200.0f);
-				ConfigWidget("Smoothing", f_Smoothing, 0.01f, 0.001f, 1.0f, "Lower = Smoother");
+				ConfigWidget("Field of View", f_FOV, 0.1f, 0.01f, 200.0f, "Changes Vertical FoV. Horizontal FoV depends on the viewport's aspect ratio");
+				if (ImGui::Button("Convert FoV to 35mm FF focal length"))
+					focalLength = 24 / (2 * tan((f_FOV * 3.14159265) / (2 * 180)));
+				ImGui::Text("Focal length: %f", focalLength);
+				ImGui::Spacing();
+				ConfigWidget("Movement Smoothing", f_MovSmoothing, 0.01f, 0.001f, 1.0f, "Lower = Smoother");
+				ConfigWidget("Look Smoothing", f_LookSmoothing, 0.01f, 0.001f, 1.0f, "Lower = Smoother");
+				ConfigWidget("Roll Smoothing", f_RollSmoothing, 0.01f, 0.001f, 1.0f, "Lower = Smoother");
+				ConfigWidget("FOV Smoothing", f_FovSmoothing, 0.01f, 0.001f, 1.0f, "Lower = Smoother");
 			}
 			ImGui::EndGroupPanel();
 
@@ -127,11 +138,11 @@ namespace cheat::feature
 			roll = t_eulerAngles.z;
 		}
 
-		void LerpTowards(CameraRotation target, float rotationLerpPct)
+		void LerpTowards(CameraRotation target, float lookRotationLerpPct, float rollRotationLerpPct)
 		{
-			yaw = app::Mathf_Lerp(yaw, target.yaw, rotationLerpPct, nullptr);
-			pitch = app::Mathf_Lerp(pitch, target.pitch, rotationLerpPct, nullptr);
-			roll = app::Mathf_Lerp(roll, target.roll, rotationLerpPct, nullptr);
+			yaw = app::Mathf_Lerp(yaw, target.yaw, lookRotationLerpPct, nullptr);
+			pitch = app::Mathf_Lerp(pitch, target.pitch, lookRotationLerpPct, nullptr);
+			roll = app::Mathf_Lerp(roll, target.roll, rollRotationLerpPct, nullptr);
 		}
 
 		void UpdateTransform(app::Transform* t)
@@ -204,11 +215,11 @@ namespace cheat::feature
 		// Commit the rotation changes to the transform
 		currentRotation.UpdateTransform(freeCam_Transform);
 
-		smoothPosition = app::Vector3_Lerp(freeCam_Transform_position, targetPosition, settings.f_Smoothing, nullptr);
+		smoothPosition = app::Vector3_Lerp(freeCam_Transform_position, targetPosition, settings.f_MovSmoothing, nullptr);
 		app::Transform_set_position(freeCam_Transform, smoothPosition, nullptr);
-		smoothFOV = app::Mathf_Lerp(app::Camera_get_fieldOfView(reinterpret_cast<app::Camera*>(freeCam_Camera), nullptr), settings.f_FOV, settings.f_Smoothing, nullptr);
+		smoothFOV = app::Mathf_Lerp(app::Camera_get_fieldOfView(reinterpret_cast<app::Camera*>(freeCam_Camera), nullptr), settings.f_FOV, settings.f_FovSmoothing, nullptr);
 		app::Camera_set_fieldOfView(reinterpret_cast<app::Camera*>(freeCam_Camera), smoothFOV, nullptr);
-		currentRotation.LerpTowards(targetRotation, settings.f_Smoothing);
+		currentRotation.LerpTowards(targetRotation, settings.f_LookSmoothing, settings.f_RollSmoothing);
 	}
 
 	void DisableFreeCam()

--- a/cheat-library/src/user/cheat/visuals/FreeCamera.cpp
+++ b/cheat-library/src/user/cheat/visuals/FreeCamera.cpp
@@ -80,7 +80,7 @@ namespace cheat::feature
 				ConfigWidget("FOV Speed", f_FOVSpeed, 0.01f, 0.01f, 100.0f);
 				ConfigWidget("Field of View", f_FOV, 0.1f, 0.01f, 200.0f, "Changes Vertical FoV. Horizontal FoV depends on the viewport's aspect ratio");
 				if (ImGui::Button("Convert FoV to 35mm FF focal length"))
-					focalLength = 24 / (2 * tan((f_FOV * 3.14159265) / (2 * 180)));
+					focalLength = 24 / (2 * tan((f_FOV * 3.14159265) / (2 * 180))); // FocalLength = (vertical) sensor size / 2 * tan( 2*(vertical) FoV * Pi / 180)  Remember to convert degree to radian.  
 				ImGui::Text("Focal length: %f", focalLength);
 				ImGui::Spacing();
 				ConfigWidget("Movement Smoothing", f_MovSmoothing, 0.01f, 0.001f, 1.0f, "Lower = Smoother");

--- a/cheat-library/src/user/cheat/visuals/FreeCamera.h
+++ b/cheat-library/src/user/cheat/visuals/FreeCamera.h
@@ -16,7 +16,10 @@ namespace cheat::feature
 		config::Field<float> f_RollSpeed;
 		config::Field<float> f_FOVSpeed;
 		config::Field<float> f_FOV;
-		config::Field<float> f_Smoothing;
+		config::Field<float> f_MovSmoothing;
+		config::Field<float> f_LookSmoothing;
+		config::Field<float> f_RollSmoothing;
+		config::Field<float> f_FovSmoothing;
 		config::Field<Hotkey> f_Forward;
 		config::Field<Hotkey> f_Backward;
 		config::Field<Hotkey> f_Left;


### PR DESCRIPTION
1.把Freecam裡面 移動/視角/Fov的smoothing分開調整(方便運鏡)
Seperate settings of Movement/Camera/Roll/Fov smoothing.

2.用FoV計算 35mm 全畫幅 鏡頭焦距
Calculate FoV to 35mm full frame focal length in game.