### PR TITLE
sumeru animal vacuum filter moved

### DIFF
--- a/cheat-library/src/user/cheat/game/filters.cpp
+++ b/cheat-library/src/user/cheat/game/filters.cpp
@@ -409,7 +409,10 @@ namespace cheat::game::filters
 			living::Squirrel,
 			living::Boar,
 			living::Weasel,
-			living::DuskBird
+			living::DuskBird,
+			monster::ShaggySumpterBeast,
+			monster::RishbolandTiger,
+			monster::Spincrocodile
 		};
 		SimpleFilter AnimalPickUp = {
 			living::CrystalCore,
@@ -454,9 +457,7 @@ namespace cheat::game::filters
 			monster::WhirlingFungus,
 			monster::WingedShroom,
 			monster::GroundedShroom,
-			monster::ShaggySumpterBeast,
-			monster::RishbolandTiger,
-			monster::Spincrocodile
+			monster::ShaggySumpterBeast
 		};
 		SimpleFilter MonsterElites = {
 			monster::Mitachurl,


### PR DESCRIPTION
sumeru vacuum meat source for paimon burger

* These two although tough, it only drops meat
   * Spinocrocodile
   * Rishboland Tiger


* This one have monster drops and includes meat
   * Shaggy Sumpter Beast