### PR TITLE
Clamp input values

### DIFF
--- a/cheat-base/src/cheat-base/render/gui-util.cpp
+++ b/cheat-base/src/cheat-base/render/gui-util.cpp
@@ -78,7 +78,7 @@ bool TypeWidget(const char* label, int& value, int step, int start, int end, con
     if (start == end)
         result = ImGui::InputInt(label, &value, step);
     else
-        result = ImGui::DragInt(label, &value, (float)step, start, end);
+        result = ImGui::DragInt(label, &value, (float)step, start, end, nullptr, ImGuiSliderFlags_AlwaysClamp);
 
     END_TYPE_WIDGET();
 }
@@ -90,7 +90,7 @@ bool TypeWidget(const char* label, float& value, float step, float start, float 
     if (start == end)
         result = ImGui::InputFloat(label, &value, step);
     else
-        result = ImGui::DragFloat(label, &value, step, start, end);
+        result = ImGui::DragFloat(label, &value, step, start, end, nullptr, ImGuiSliderFlags_AlwaysClamp);
 
     END_TYPE_WIDGET();
 }

--- a/cheat-library/src/user/cheat/player/RapidFire.cpp
+++ b/cheat-library/src/user/cheat/player/RapidFire.cpp
@@ -64,7 +64,7 @@ namespace cheat::feature
 			}
 			else
 			{
-				ConfigWidget("Min Multiplier", f_minMultiplier, 1, 2, 1000, "Attack count minimum multiplier.");
+				ConfigWidget("Min Multiplier", f_minMultiplier, 1, 1, 1000, "Attack count minimum multiplier.");
 				ConfigWidget("Max Multiplier", f_maxMultiplier, 1, 2, 1000, "Attack count maximum multiplier.");
 			}
 		}
@@ -157,7 +157,10 @@ namespace cheat::feature
 		}
 		if (f_Randomize)
 		{
-			countOfAttacks = rand() % (f_maxMultiplier.value() - f_minMultiplier.value()) + f_minMultiplier.value();
+			if (f_minMultiplier.value() >= f_maxMultiplier.value()) 
+				countOfAttacks = f_minMultiplier.value();
+			else
+				countOfAttacks = rand() % (f_maxMultiplier.value() - f_minMultiplier.value()) + f_minMultiplier.value();
 			return countOfAttacks;
 		}
 


### PR DESCRIPTION
Addressing issues from the discussion in PR #586.
Clamping the slider input to at least makes it easier for players to know the value limit and prevent crashes when they try override the allowed limit. Now it will skip randomization if min & max value is just the same and set min value as the default when min > max.

@andiabrudan @ScriptKid05 Does this resolve the issue?