### PR TITLE
Added Set Collider for Mob Vacuum

### DIFF
--- a/cheat-library/src/user/cheat/world/MobVacuum.cpp
+++ b/cheat-library/src/user/cheat/world/MobVacuum.cpp
@@ -146,14 +146,23 @@ namespace cheat::feature
 
     // Set Monster's collider
     // Taiga#5555: There might be an in-game function for this already I'm just not sure which one
-    void SetMonsterCollider(game::Entity* entity, bool v)
+    void SetMonsterCollider(bool v)
     {
-        auto objName = entity->name();
-        auto name = objName.substr(0, objName.find_first_of(" "));
-        // path example: "EntityRoot/MonsterRoot/Monster_Fungus_Raptor_01(Clone)/Collider"
-        auto collider = app::GameObject_Find(string_to_il2cppi("/EntityRoot/MonsterRoot/" + name + "/Collider"), nullptr);
-        if (collider != nullptr)
-            app::GameObject_SetActive(collider, v, nullptr);
+        auto monsterRoot = app::GameObject_Find(string_to_il2cppi("/EntityRoot/MonsterRoot"), nullptr);
+        if (monsterRoot != nullptr)
+        {
+            auto transform = app::GameObject_GetComponentByName(monsterRoot, string_to_il2cppi("Transform"), nullptr);
+            auto monsterCount = app::Transform_get_childCount(reinterpret_cast<app::Transform*>(transform), nullptr);
+            for (int i = 0; i <= monsterCount - 1; i++)
+            {
+                auto monsters = app::Transform_GetChild(reinterpret_cast<app::Transform*>(transform), i, nullptr);
+                auto monsterGameObject = app::Component_1_get_gameObject(reinterpret_cast<app::Component_1*>(monsters), nullptr);
+                auto monsterTransform = app::GameObject_GetComponentByName(monsterGameObject, string_to_il2cppi("Transform"), nullptr);
+                auto transformChild = app::Transform_GetChild(reinterpret_cast<app::Transform*>(monsterTransform), 1, nullptr);
+                auto colliderGameObject = app::Component_1_get_gameObject(reinterpret_cast<app::Component_1*>(transformChild), nullptr);
+                app::GameObject_SetActive(colliderGameObject, v, nullptr);
+            }
+        }
     }
 
     // Mob vacuum update function.
@@ -183,7 +192,7 @@ namespace cheat::feature
             if (!IsEntityForVac(entity))
                 continue;
 
-            SetMonsterCollider(entity, !f_SetCollider);
+            SetMonsterCollider(!f_SetCollider);
 
             if (f_Instantly)
             {
@@ -227,7 +236,7 @@ namespace cheat::feature
         if (!IsEntityForVac(entity))
             return;
 
-        SetMonsterCollider(entity, !f_SetCollider);
+        SetMonsterCollider(!f_SetCollider);
 
         app::Vector3 targetPos = CalcMobVacTargetPos();
         app::Vector3 entityPos = entity->relativePosition();

--- a/cheat-library/src/user/cheat/world/MobVacuum.cpp
+++ b/cheat-library/src/user/cheat/world/MobVacuum.cpp
@@ -22,7 +22,8 @@ namespace cheat::feature
         NF(f_Distance,   "Distance",      "MobVacuum", 1.5f),
         NF(f_Radius,     "Radius",        "MobVacuum", 10.0f),
         NF(f_OnlyTarget, "Only targeted", "MobVacuum", true),
-        NF(f_Instantly,  "Instantly",     "MobVacuum", false)
+        NF(f_Instantly,  "Instantly",     "MobVacuum", false),
+        NF(f_SetCollider, "SetCollider", "MobVacuum", false)
     {
         events::GameUpdateEvent += MY_METHOD_HANDLER(MobVacuum::OnGameUpdate);
         events::MoveSyncEvent += MY_METHOD_HANDLER(MobVacuum::OnMoveSync);
@@ -63,6 +64,7 @@ namespace cheat::feature
 
     	ConfigWidget("Instant Vacuum", f_Instantly, "Vacuum entities instantly.");
         ConfigWidget("Only Hostile/Aggro", f_OnlyTarget, "If enabled, vacuum will only affect monsters targeting you. Will not affect animals.");
+        ConfigWidget("Remove Collider", f_SetCollider, "If enabled, monsters won't be able to push you despite the distance or size");
         ConfigWidget("Speed", f_Speed, 0.1f, 1.0f, 15.0f, "If 'Instant Vacuum' is not checked, mob will be vacuumed at the specified speed.");
         ConfigWidget("Radius (m)", f_Radius, 0.1f, 5.0f, 150.0f, "Radius of vacuum.");
         ConfigWidget("Distance (m)", f_Distance, 0.1f, 0.5f, 10.0f, "Distance between the player and the monster.");
@@ -75,13 +77,13 @@ namespace cheat::feature
 
     void MobVacuum::DrawStatus() 
     { 
-        ImGui::Text("Vacuum [%s]\n[%s|%.01fm|%.01fm|%s]", 
+        ImGui::Text("Vacuum [%s]\n[%s|%.01fm|%.01fm|%s|%s]",
             f_IncludeMonsters && f_IncludeAnimals ? "All" : f_IncludeMonsters ? "Monsters" : f_IncludeAnimals ? "Animals" : "None",
             f_Instantly ? "Instant" : fmt::format("Normal|{:.1f}", f_Speed.value()).c_str(),
             f_Radius.value(),
             f_Distance.value(),
-            f_OnlyTarget ? "Aggro" : "All"
-        );
+            f_OnlyTarget ? "Aggro" : "All",
+            f_SetCollider ? "RCollider" : "ECollider");
     }
 
     MobVacuum& MobVacuum::GetInstance()
@@ -142,6 +144,18 @@ namespace cheat::feature
         return avatarEntity->relativePosition() + avatarEntity->forward() * f_Distance;
     }
 
+    // Set Monster's collider
+    // Taiga#5555: There might be an in-game function for this already I'm just not sure which one
+    void SetMonsterCollider(game::Entity* entity, bool v)
+    {
+        auto objName = entity->name();
+        auto name = objName.substr(0, objName.find_first_of(" "));
+        // path example: "EntityRoot/MonsterRoot/Monster_Fungus_Raptor_01(Clone)/Collider"
+        auto collider = app::GameObject_Find(string_to_il2cppi("/EntityRoot/MonsterRoot/" + name + "/Collider"), nullptr);
+        if (collider != nullptr)
+            app::GameObject_SetActive(collider, v, nullptr);
+    }
+
     // Mob vacuum update function.
     // Changes position of monster, if mob vacuum enabled.
     void MobVacuum::OnGameUpdate()
@@ -168,6 +182,8 @@ namespace cheat::feature
         {
             if (!IsEntityForVac(entity))
                 continue;
+
+            SetMonsterCollider(entity, !f_SetCollider);
 
             if (f_Instantly)
             {
@@ -210,6 +226,8 @@ namespace cheat::feature
         auto entity = manager.entity(entityId);
         if (!IsEntityForVac(entity))
             return;
+
+        SetMonsterCollider(entity, !f_SetCollider);
 
         app::Vector3 targetPos = CalcMobVacTargetPos();
         app::Vector3 entityPos = entity->relativePosition();

--- a/cheat-library/src/user/cheat/world/MobVacuum.cpp
+++ b/cheat-library/src/user/cheat/world/MobVacuum.cpp
@@ -83,7 +83,7 @@ namespace cheat::feature
             f_Radius.value(),
             f_Distance.value(),
             f_OnlyTarget ? "Aggro" : "All",
-            f_SetCollider ? "RCollider" : "ECollider");
+            f_SetCollider ? "RC" : "");
     }
 
     MobVacuum& MobVacuum::GetInstance()

--- a/cheat-library/src/user/cheat/world/MobVacuum.h
+++ b/cheat-library/src/user/cheat/world/MobVacuum.h
@@ -29,6 +29,7 @@ namespace cheat::feature
 		config::Field<float> f_Distance;
 		config::Field<bool> f_OnlyTarget;
 		config::Field<bool> f_Instantly;
+		config::Field<config::Toggle<Hotkey>> f_SetCollider;
 
 		static MobVacuum& GetInstance();
 


### PR DESCRIPTION
Allows you to disable monster entity's collider so that it doesn't push you when using Mob Vacuum despite the monster's size or distance between the player which is an issue addressed in #608 .

Demo:

https://user-images.githubusercontent.com/67109235/188064232-b5a0fcd7-3579-412a-bf46-480b3b0dc039.mp4

