### PR TITLE
Add a held down toggle hotkey option for AutoTalk

### DIFF
--- a/cheat-library/src/user/cheat/world/DialogSkip.h
+++ b/cheat-library/src/user/cheat/world/DialogSkip.h
@@ -9,6 +9,7 @@ namespace cheat::feature
 	{
 	public:
 		config::Field<config::Toggle<Hotkey>> f_Enabled;
+		config::Field<Hotkey> f_ToggleHotkey;
 		config::Field<config::Toggle<Hotkey>> f_AutoSelectDialog;
 		config::Field<config::Toggle<Hotkey>> f_ExcludeImportant;
 		config::Field<config::Toggle<Hotkey>> f_FastDialog;


### PR DESCRIPTION
I was gonna open an issue to suggest this but it was simple enough to implement. Basically just added a similar toggle hotkey feature like in Gamespeed, for those who prefer holding down a button to skip dialog instead of an on/off toggle.